### PR TITLE
Promote Default Key

### DIFF
--- a/.sync.toml
+++ b/.sync.toml
@@ -1,4 +1,5 @@
 rsync_options = ["-v"]
+default = "secondhost"
 
 [firsthost]
 	hostname = "first"
@@ -9,7 +10,6 @@ rsync_options = ["-v"]
 	hostname = "second"
 	remote_folder = "/something/"
 	rsync_options = ["-v"]
-	default = true
 
 [inversehost]
 	hostname = "second"

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ The available keys are:
 * **`hostname`**: A hostname to be understood by `rsync`. Hint: Use aliases in your `~/.ssh/config/`!
 * **`target_folder`**: The target directory to be syncing to (remote or local).
 * **`rsync_options`**: An array of strings of `rsync` options. They are used in addition to the default, basic options hardcoded into the Python program and the options supplied by the command line call.
-* **`default`**: A boolean (either `true` or `false` or not given) whether or not the current entry is the default. You yourself are responsible for preventing multiple defaults.
 * **`source_folder`**: Usually, Rsync By Config is expected to work from the current directory of invocation. Setting this value changes this behavior explicitly. Useful in combination with `gather`, see next section.
 
 **Note**: `remote_folder` and `local_folder` are deprecated and will be removed soon™! There's a handy little command in the warning to convert config files.
 
-Additionally to the parameters of an entry, *global* parameters true for all entries in the config file can be specified. The parameters need to be specified before the first entry occurs. Currently, only `rsync_options` is supported. Example:
+Additionally to the parameters of an entry, *global* parameters for all entries in the config file can be specified. The parameters need to be specified before the first entry occurs. Currently, a global `rsync_options` and the selection of a `default` entry are supported. The default entry is chosen if no entry is selected dedicatedly via the command line. Example:
 
 ```toml
 rsync_options = ['-v']
+default = "firsthost"
 
 [firsthost]
     hostname = "first"

--- a/rbc.py
+++ b/rbc.py
@@ -291,7 +291,7 @@ def parseEntries(cfg, entry):
 @click.option("--listhosts", is_flag=True, help="List available hosts in config_file.")
 @click.argument('entry', default="")
 def main(entry, monitor, config_file, rsync_options, dryrun, verbose, listhosts):
-	"""Use the entry of ENTRY in config_file to synchronize the files of the current directory to. If ENTRY is not specified, the entry of config_file with 'default = true' is taken. If no default entry is specified, some entry is taken (which might be the first in the config file, but does not need to be).
+	"""Use the entry of ENTRY in config_file to synchronize the files of the current directory to. If ENTRY is not specified, the entry of config_file specified as a global 'default = ENTRY' is taken. If no default key is specified, some entry is taken (which is usually but not guaranteed to be the first).
 
 
 	The structure of the config file should be of the following:
@@ -299,8 +299,7 @@ def main(entry, monitor, config_file, rsync_options, dryrun, verbose, listhosts)
 	[entry]\n
 		hostname = \"remotecomputer\"\n
 		target_folder = \"/user/myuser/directory/\"\n
-		rsync_options = [\"--a\", \"--b\"]\n
-		default = true
+		rsync_options = [\"--a\", \"--b\"]
 
 	Additional keywords for an entry in a config file are:\n
 		* source_folder: Explicitly set the source directory to this value\n

--- a/rbc.py
+++ b/rbc.py
@@ -236,9 +236,12 @@ def parseDefaultEntry(verbose, config):
 	for en in config:
 		if "default" in config[en]:
 			if config[en]["default"] is True:
-				entry = en
-				print("# Found default entry {}".format(en))
-				print("Using entry: {}".format(en))
+				print("default key for individual entries is deprecated and not supported anymore. Please set 'default = {}' in your configuration file!".format(en))
+	if "default" in config:
+		default_entry = config["default"]
+		if default_entry in config:
+			print("# Using default host {}".format(default_entry))
+			entry = default_entry
 	return [entry]  # Multi host default entry not yet supported
 
 

--- a/test/.sync.toml
+++ b/test/.sync.toml
@@ -1,3 +1,5 @@
+default = "lhost"
+
 [wrongsource]
 	hostname = "lhost"
 	source_folder = "~/RBC/"
@@ -11,7 +13,6 @@
 [lhost]
 	hostname = "lhost"
 	target_folder = "~/test/rbc/"
-	default = true
 
 [lhostVerbose]
 	hostname = "lhost"

--- a/test/test_configfileoptions.bats
+++ b/test/test_configfileoptions.bats
@@ -11,7 +11,7 @@ teardown() {
 
 @test "Default entry" {
 	run ../rbc.py
-	assert_output --partial "# Found default entry lhost"
+	assert_output --partial "# Using default host lhost"
 	assert_success
 }
 


### PR DESCRIPTION
`default` now is global key and not a property of an entry anymore. Benefit: There can only be one `default` entry now. (Well, there can be multiple, but then the first is chosen.)

Use with

```toml
default = "myhost"

[myhost]
# options
```

Tests have been modified accordingly, and so has the documentation.

This implements the enhancement suggested in issue #9.